### PR TITLE
Remove explicit usage of GCC11 as GCC11 will now be default compiler

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ set -ex
 
 export USE_OPENMP=1
 
-if [[ $ppc_arch != "p10" ]]
+if [[ $ppc_arch != "p10" ]]; then
     export LDFLAGS="${LDFLAGS} -L$PREFIX/lib -L$BUILD_PREFIX/lib"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,19 +19,7 @@ set -ex
 
 export USE_OPENMP=1
 
-PATH_VAR="$PATH"
-if [[ $ppc_arch == "p10" ]]
-then
-    if [[ -z "${GCC_11_HOME}" ]];
-    then
-        echo "Please set GCC_11_HOME to the install path of gcc-toolset-11"
-        exit 1
-    else
-        export PATH=${GCC_11_HOME}/bin/:$PATH
-    fi
-    GCC_USED=`which gcc`
-    echo "GCC being used is ${GCC_USED}"
-else
+if [[ $ppc_arch != "p10" ]]
     export LDFLAGS="${LDFLAGS} -L$PREFIX/lib -L$BUILD_PREFIX/lib"
 fi
 
@@ -210,5 +198,3 @@ echo library_dirs = ${PREFIX}/lib >> "${PREFIX}"/site.cfg
 echo include_dirs = ${PREFIX}/include >> "${PREFIX}"/site.cfg
 echo runtime_include_dirs = ${PREFIX}/lib >> "${PREFIX}"/site.cfg
 
-#Restore PATH variable
-export PATH="$PATH_VAR"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,12 @@ source:
     #- gh2111.patch
 
 build:
-  number: 2
+  number: 3
   missing_dso_whitelist:
     # Mildly concerned this triggers an overlinking warning, but it may be a
     # sign some S390X-specific changes needed in conda-build.  Leaving this in
     # while we investigate so the linux-s390x build out can continue.
     - "*/ld64.so.1"   # [s390x]
-  script_env:                 #[ppc_arch == 'p10']
-    - GCC_11_HOME             #[ppc_arch == 'p10']
 
 requirements:
   build:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Earlier we had explicitly made the recipe to use GCC11 as GCC 10 was default compiler for P10 builds. But now since we are changing default compiler to GCC 11, this extra code isn't needed anymore.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
